### PR TITLE
Changes to get the ldscore rg option to work on a test data set

### DIFF
--- a/ldsc.py
+++ b/ldsc.py
@@ -842,7 +842,8 @@ if __name__ == "__main__":
                     raise ValueError("Must set either --frqfile and --ref-ld or --frqfile-chr and --ref-ld-chr")
 
             if args.rg:
-                sumstats.estimate_rg(args, log)
+                sumstats.estimate_genetic_correlation(args, log)
+                # sumstats.estimate_rg(args, log)
             elif args.h2:
                 sumstats.estimate_h2(args, log)
             elif args.h2_cts:

--- a/ldscore/sumstats.py
+++ b/ldscore/sumstats.py
@@ -162,7 +162,8 @@ def read_reference_ld_scores(args: Any, logger: Any) -> pd.DataFrame:
         elif args.ref_ld_chr:
             pattern = ps.sub_chr(args.ref_ld_chr, "[1-22]")
             logger.log(f"Reading reference panel LD Scores from {pattern} ...")
-            ref_ld = ps.ldscore_fromlist(split_paths(args.ref_ld_chr))
+            ref_ld = ps.ldscore_fromlist(split_paths(args.ref_ld_chr), num=NUM_CHROMOSOMES)
+            # ref_ld = ps.ldscore_fromlist(split_paths(args.ref_ld_chr))
         else:
             raise ValueError("No reference LD Scores provided.")
     except Exception as e:
@@ -225,7 +226,8 @@ def read_m(args: Any, logger: Any, num_annotations: int) -> np.ndarray:
         if args.ref_ld:
             m_annot_list = ps.M_fromlist(split_paths(args.ref_ld), common=(not args.not_M_5_50))
         elif args.ref_ld_chr:
-            m_annot_list = ps.M_fromlist(split_paths(args.ref_ld_chr), common=(not args.not_M_5_50))
+            m_annot_list = ps.M_fromlist(split_paths(args.ref_ld_chr), num=NUM_CHROMOSOMES, common=(not args.not_M_5_50))
+            # m_annot_list = ps.M_fromlist(split_paths(args.ref_ld_chr), common=(not args.not_M_5_50))
         else:
             raise ValueError("No reference LD Scores provided for M.")
 
@@ -260,7 +262,8 @@ def read_regression_weight_ld_scores(args: Any, logger: Any) -> pd.DataFrame:
         elif args.w_ld_chr:
             pattern = ps.sub_chr(args.w_ld_chr, "[1-22]")
             logger.log(f"Reading regression weight LD Scores from {pattern} ...")
-            w_ld = ps.ldscore_fromlist(split_paths(args.w_ld_chr))
+            w_ld = ps.ldscore_fromlist(split_paths(args.w_ld_chr), num = NUM_CHROMOSOMES)
+            # w_ld = ps.ldscore_fromlist(split_paths(args.w_ld_chr))
         else:
             raise ValueError("No regression weight LD Scores provided.")
     except Exception as e:


### PR DESCRIPTION
When we tried to get this test run of the `rg` option to work in conjunction with the `--ref-ld-chr` and `--w-ld-chr` options

```
./ldsc.py \
--out scz_bip \
--rg scz.sumstats.gz,bip.sumstats.gz \
--ref-ld-chr ./eur_w_ld_chr/ \
--w-ld-chr ./eur_w_ld_chr/
```

we had to make several changes to get this to run.  

It appears that what used to be called

```
sumstats.estimate_rg(args, log)
```

is now called

```
sumstats.estimate_genetic_correlation(args, log)
```

We also found that the calls that used `_fromlist(split_paths(args.ref_ld_chr))` like this:

```
ref_ld = ps.ldscore_fromlist(split_paths(args.ref_ld_chr))
```

failed.  Changing them like this got them to work:

```
ref_ld = ps.ldscore_fromlist(split_paths(args.ref_ld_chr), num=NUM_CHROMOSOMES)
```

However, while these fixes appear to be working properly, we have not verified that the results obtained are identical to those obtained by the original Python 2 version of ldsc as we don't yet have Python 2 installed on our computational cluster.   

Note also that this is a narrow fix focused on getting  the `rg` option to work in conjunction with the `--ref-ld-chr` and `--w-ld-chr` options.  